### PR TITLE
Support .NET Core.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ obj/
 bin/
 private/
 !private/.gitkeep
+*.user
+*.suo
 
 # ReSharper
 _ReSharper*/

--- a/build.ps1
+++ b/build.ps1
@@ -3,10 +3,10 @@ If ($lastexitcode -ne 0) {
 	Write-Host "Restore failed."
 	exit 1
 }
-dotnet test $PSScriptRoot\tests\OpenVsixSignTool.Core.Tests\OpenVsixSignTool.Core.Tests.csproj
+dotnet test --framework net462 $PSScriptRoot\tests\OpenVsixSignTool.Core.Tests\OpenVsixSignTool.Core.Tests.csproj
 $CoreTestsFailed = $lastexitcode
 
-dotnet test $PSScriptRoot\tests\OpenVsixSignTool.Tests\OpenVsixSignTool.Tests.csproj
+dotnet test --framework net462 $PSScriptRoot\tests\OpenVsixSignTool.Tests\OpenVsixSignTool.Tests.csproj
 $IntegrationTestsFailed = $lastexitcode
 
 If (($CoreTestsFailed -ne 0) -or ($IntegrationTestsFailed -ne 0)) {

--- a/src/OpenVsixSignTool.Core/Interop/Crypt32.cs
+++ b/src/OpenVsixSignTool.Core/Interop/Crypt32.cs
@@ -17,7 +17,7 @@ namespace OpenVsixSignTool.Core.Interop
             [param: In, MarshalAs(UnmanagedType.U4)] CryptRetrieveTimeStampRetrievalFlags dwRetrievalFlags,
             [param: In, MarshalAs(UnmanagedType.U4)] uint dwTimeout,
             [param: In, MarshalAs(UnmanagedType.LPStr)] string pszHashId,
-            [param: In, MarshalAs(UnmanagedType.Struct)] ref CRYPT_TIMESTAMP_PARA pPara,
+            [param: In] ref CRYPT_TIMESTAMP_PARA pPara,
             [param: In, MarshalAs(UnmanagedType.LPArray)] byte[] pbData,
             [param: In, MarshalAs(UnmanagedType.U4)] uint cbData,
             [param: Out] out CryptMemorySafeHandle ppTsContext,

--- a/src/OpenVsixSignTool.Core/OpcPackageTimestampBuilder.cs
+++ b/src/OpenVsixSignTool.Core/OpcPackageTimestampBuilder.cs
@@ -1,10 +1,19 @@
-﻿using OpenVsixSignTool.Core.Interop;
-using System;
+﻿using System;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
+using System.Net.Http;
+
+#if NETSTANDARD2_0
+using System.Net;
+using Org.BouncyCastle.Tsp;
+using Org.BouncyCastle.Asn1;
+using Org.BouncyCastle.Asn1.Tsp;
+#elif NET462
+using OpenVsixSignTool.Core.Interop;
+#endif
 
 namespace OpenVsixSignTool.Core
 {
@@ -43,58 +52,100 @@ namespace OpenVsixSignTool.Core
             {
                 throw new ArgumentException("The timestamp server must be an absolute URI.", nameof(timestampServer));
             }
-            var oid = HashAlgorithmTranslator.TranslateFromNameToOid(timestampAlgorithm);
             using (var nonce = new TimestampNonceFactory())
             {
-                var parameters = new CRYPT_TIMESTAMP_PARA();
-                parameters.cExtension = 0;
-                parameters.fRequestCerts = true;
-                parameters.Nonce.cbData = nonce.Size;
-                parameters.Nonce.pbData = nonce.Nonce;
-                parameters.pszTSAPolicyId = null;
-                var (signatureDocument, timestampSubject) = GetSignatureToTimestamp(_part);
-                var winResult = Crypt32.CryptRetrieveTimeStamp(
-                    timestampServer.AbsoluteUri,
-                    CryptRetrieveTimeStampRetrievalFlags.NONE,
-                    (uint)Timeout.TotalMilliseconds,
-                    oid.Value,
-                    ref parameters,
-                    timestampSubject,
-                    (uint)timestampSubject.Length,
-                    out var context,
-                    IntPtr.Zero,
-                    IntPtr.Zero
-                );
-                if (!winResult)
+#if NET462 
+                return Win32TimeStamp(timestampServer, timestampAlgorithm, nonce);
+#elif NETSTANDARD2_0
+                return BouncyCastleTimeStamp(timestampServer, timestampAlgorithm, nonce);
+#else
+                throw new PlatformNotSupportedException("Timestamping is not supported on this platform.");
+#endif
+            }
+        }
+
+#if NETSTANDARD2_0
+        private async Task<TimestampResult> BouncyCastleTimeStamp(Uri timestampServer, HashAlgorithmName timestampAlgorithm, TimestampNonceFactory nonce)
+        {
+            var oid = HashAlgorithmTranslator.TranslateFromNameToOid(timestampAlgorithm);
+            var requestGenerator = new TimeStampRequestGenerator();
+            var (signatureDocument, timestampSubject) = GetSignatureToTimestamp(_part);
+            using (var hash = HashAlgorithmTranslator.TranslateFromNameToxmlDSigUri(timestampAlgorithm, out _))
+            {
+                var digest = hash.ComputeHash(timestampSubject);
+                var request = requestGenerator.Generate(oid.Value, digest, new Org.BouncyCastle.Math.BigInteger(nonce.Nonce));
+                var encodedRequest = request.GetEncoded();
+                var client = new HttpClient();
+                var content = new ByteArrayContent(encodedRequest);
+                content.Headers.Add("Content-Type", "application/timestamp-query");
+                var post = await client.PostAsync(timestampServer, content);
+                if (post.StatusCode != HttpStatusCode.OK)
                 {
-                    return Task.FromResult(TimestampResult.Failed);
+                    return TimestampResult.Failed;
                 }
-                using (context)
+                var responseBytes = await post.Content.ReadAsByteArrayAsync();
+                var responseParser = new Asn1StreamParser(responseBytes);
+                var timeStampResponse = new TimeStampResponse(responseBytes);
+                var tokenResponse = timeStampResponse.TimeStampToken.GetEncoded();
+                ApplyTimestamp(signatureDocument, _part, tokenResponse);
+                return TimestampResult.Success;
+            }
+        }
+#endif
+
+#if NET462
+        private Task<TimestampResult> Win32TimeStamp(Uri timestampServer, HashAlgorithmName timestampAlgorithm, TimestampNonceFactory nonce)
+        {
+            var oid = HashAlgorithmTranslator.TranslateFromNameToOid(timestampAlgorithm);
+            var parameters = new CRYPT_TIMESTAMP_PARA();
+            parameters.cExtension = 0;
+            parameters.fRequestCerts = true;
+            parameters.Nonce.cbData = nonce.Size;
+            parameters.Nonce.pbData = nonce.NoncePointer;
+            parameters.pszTSAPolicyId = null;
+            var (signatureDocument, timestampSubject) = GetSignatureToTimestamp(_part);
+            var winResult = Crypt32.CryptRetrieveTimeStamp(
+                timestampServer.AbsoluteUri,
+                CryptRetrieveTimeStampRetrievalFlags.NONE,
+                (uint)Timeout.TotalMilliseconds,
+                oid.Value,
+                ref parameters,
+                timestampSubject,
+                (uint)timestampSubject.Length,
+                out var context,
+                IntPtr.Zero,
+                IntPtr.Zero
+            );
+            if (!winResult)
+            {
+                return Task.FromResult(TimestampResult.Failed);
+            }
+            using (context)
+            {
+                var refSuccess = false;
+                try
                 {
-                    var refSuccess = false;
-                    try
+                    context.DangerousAddRef(ref refSuccess);
+                    if (!refSuccess)
                     {
-                        context.DangerousAddRef(ref refSuccess);
-                        if (!refSuccess)
-                        {
-                            return Task.FromResult(TimestampResult.Failed);
-                        }
-                        var structure = Marshal.PtrToStructure<CRYPT_TIMESTAMP_CONTEXT>(context.DangerousGetHandle());
-                        var encoded = new byte[structure.cbEncoded];
-                        Marshal.Copy(structure.pbEncoded, encoded, 0, encoded.Length);
-                        ApplyTimestamp(signatureDocument, _part, encoded);
-                        return Task.FromResult(TimestampResult.Success);
+                        return Task.FromResult(TimestampResult.Failed);
                     }
-                    finally
+                    var structure = Marshal.PtrToStructure<CRYPT_TIMESTAMP_CONTEXT>(context.DangerousGetHandle());
+                    var encoded = new byte[structure.cbEncoded];
+                    Marshal.Copy(structure.pbEncoded, encoded, 0, encoded.Length);
+                    ApplyTimestamp(signatureDocument, _part, encoded);
+                    return Task.FromResult(TimestampResult.Success);
+                }
+                finally
+                {
+                    if (refSuccess)
                     {
-                        if (refSuccess)
-                        {
-                            context.DangerousRelease();
-                        }
+                        context.DangerousRelease();
                     }
                 }
             }
         }
+#endif
 
         private static (XDocument document, byte[] signature) GetSignatureToTimestamp(OpcPart signaturePart)
         {
@@ -134,24 +185,26 @@ namespace OpenVsixSignTool.Core
         {
             private readonly IntPtr _nativeMemory;
             private readonly uint _nonceSize;
+            private readonly byte[] _nonce;
 
             public TimestampNonceFactory(int nonceSize = 32)
             {
                 _nativeMemory = Marshal.AllocCoTaskMem(nonceSize);
                 _nonceSize = checked((uint)nonceSize);
-                var nonce = new byte[nonceSize];
+                _nonce = new byte[nonceSize];
                 using (var rng = RandomNumberGenerator.Create())
                 {
-                    rng.GetBytes(nonce);
+                    rng.GetBytes(_nonce);
                 }
                 //The nonce is technically an integer. Some timestamp servers may not like a "negative" nonce. Clear the sign bit so it's positive.
                 //That loses one bit of entropy, however is well within the security boundary of a properly sized nonce. Authenticode doesn't even use
                 //a nonce.
-                nonce[nonce.Length - 1] &= 0b01111111;
-                Marshal.Copy(nonce, 0, _nativeMemory, nonce.Length);
+                _nonce[_nonce.Length - 1] &= 0b01111111;
+                Marshal.Copy(_nonce, 0, _nativeMemory, _nonce.Length);
             }
 
-            public IntPtr Nonce => _nativeMemory;
+            public IntPtr NoncePointer => _nativeMemory;
+            public byte[] Nonce => _nonce;
             public uint Size => _nonceSize;
 
             public void Dispose()

--- a/src/OpenVsixSignTool.Core/OpenVsixSignTool.Core.csproj
+++ b/src/OpenVsixSignTool.Core/OpenVsixSignTool.Core.csproj
@@ -1,23 +1,28 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <AssemblyName>OpenVsixSignTool.Core</AssemblyName>
     <PackageId>OpenVsixSignTool.Core</PackageId>
     <VersionPrefix>0.1.0</VersionPrefix>
     <Authors>Kevin Jones</Authors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.13.9" />
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="2.0.6" />
     <PackageReference Include="Microsoft.Azure.KeyVault.Cryptography" Version="2.0.5" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="$(TargetFramework) == 'net462'">
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Security" />
   </ItemGroup>
+  <ItemGroup Condition="$(TargetFramework) == 'netstandard2.0'">
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="4.4.0" />
+    <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.3" />
+  </ItemGroup>
+  
 </Project>

--- a/src/OpenVsixSignTool/OpenVsixSignTool.csproj
+++ b/src/OpenVsixSignTool/OpenVsixSignTool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFrameworks>net462;netcoreapp2.0</TargetFrameworks>
     <VersionPrefix>0.1.0</VersionPrefix>
     <Authors>Kevin Jones</Authors>
   </PropertyGroup>


### PR DESCRIPTION
This uses Bouncy Castle for .NET Core builds. We can probably use
OpenSSL on Linux, and LibreSSL once it ships in macOS. For now, we can
take a dependency on BouncyCastle.

Fixes #18.