### PR TITLE
search certificate first in computer store in addition to user store

### DIFF
--- a/src/OpenVsixSignTool/SignCommand.cs
+++ b/src/OpenVsixSignTool/SignCommand.cs
@@ -297,6 +297,16 @@ namespace OpenVsixSignTool
 
         private static X509Certificate2 GetCertificateFromCertificateStore(string sha1)
         {
+            using (var store = new X509Store(StoreName.My, StoreLocation.LocalMachine))
+            {
+                store.Open(OpenFlags.OpenExistingOnly | OpenFlags.ReadOnly);
+                var certificates = store.Certificates.Find(X509FindType.FindByThumbprint, sha1, false);
+                if (certificates.Count > 0)
+                {
+                    return certificates[0];
+                }
+            }
+
             using (var store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
             {
                 store.Open(OpenFlags.OpenExistingOnly | OpenFlags.ReadOnly);
@@ -307,6 +317,7 @@ namespace OpenVsixSignTool
                 }
                 return certificates[0];
             }
+
         }
     }
 }


### PR DESCRIPTION
This will allow to use the LocalMachine store in addition to the UserStore for retrieving certificates (LocalMachine being the first one searched).
I thought about adding a command-line switch but personally I think it's not required...

I hope this satisfies your PR requirements and you'll consider merging this into your master.

Cheers