### PR TITLE
Ignore extensionless files to be compatible with the .NET GetParts

### DIFF
--- a/src/OpenVsixSignTool.Core/OpcPackage.cs
+++ b/src/OpenVsixSignTool.Core/OpcPackage.cs
@@ -86,6 +86,11 @@ namespace OpenVsixSignTool.Core
                     continue;
                 }
 
+                if (string.IsNullOrEmpty(Path.GetExtension(entry.FullName)))
+                {
+                    continue;
+                }
+
                 OpcPart part;
                 if (!_partTracker.TryGetValue(entry.FullName, out part))
                 {


### PR DESCRIPTION
The VsixInstaller validates the digital signature by comparing the signed parts with the parts returned by [System.IO.Packaging.Package.GetParts](https://referencesource.microsoft.com/#WindowsBase/Base/System/IO/Packaging/Package.cs,92c198034adfcf18).
The `GetParts` method ignores the extensionless files. Thus the VsixInstaller claims the vsix digital signature is invalid because the count of signed parts differs from the parts from the vsix returned by `GetParts`.

This is easily reproducible when creating a vsix containing a file without extension (typically License), signing it and trying to install it via the VsixInstaller.