### PR TITLE
Use SHA256 ChecksumAlgorithm

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <LangVersion>7.3</LangVersion>
+    <ChecksumAlgorithm>SHA256</ChecksumAlgorithm>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Resolve https://github.com/vcsjones/OpenOpcSignTool/issues/87.

This change switches from SHA1 (default) to SHA256.